### PR TITLE
Add tests for read-only local store

### DIFF
--- a/src/libstore/gc.cc
+++ b/src/libstore/gc.cc
@@ -114,6 +114,7 @@ void LocalStore::addTempRoot(const StorePath & path)
       debug("Read-only store doesn't support creating lock files for temp roots, but nothing can be deleted anyways.");
       return;
     }
+
     createTempRootsFile();
 
     /* Open/create the global GC lock file. */

--- a/src/libstore/gc.cc
+++ b/src/libstore/gc.cc
@@ -110,6 +110,10 @@ void LocalStore::createTempRootsFile()
 
 void LocalStore::addTempRoot(const StorePath & path)
 {
+    if (readOnly) {
+      debug("Read-only store doesn't support creating lock files for temp roots, but nothing can be deleted anyways.");
+      return;
+    }
     createTempRootsFile();
 
     /* Open/create the global GC lock file. */

--- a/tests/local.mk
+++ b/tests/local.mk
@@ -134,7 +134,8 @@ nix_tests = \
   flakes/show.sh \
   impure-derivations.sh \
   path-from-hash-part.sh \
-  toString-path.sh
+  toString-path.sh \
+  read-only-store.sh
 
 ifeq ($(HAVE_LIBCPUID), 1)
 	nix_tests += compute-levels.sh

--- a/tests/read-only-store.sh
+++ b/tests/read-only-store.sh
@@ -16,7 +16,9 @@ expectStderr 1 nix-store --store local?read-only=true --add eval.nix | grepQuiet
 # Make sure we can get an already-present store-path in the database
 nix-store --store local?read-only=true --add dummy
 
-## Ensure store is actually read-only
+## Testing read-only mode with an underlying store that is actually read-only
+
+# Ensure store is actually read-only
 chmod -R -w $TEST_ROOT/store
 chmod -R -w $TEST_ROOT/var
 

--- a/tests/read-only-store.sh
+++ b/tests/read-only-store.sh
@@ -1,0 +1,29 @@
+source common.sh
+
+clearStore
+
+## Testing read-only mode without forcing the underlying store to actually be read-only
+
+# Make sure the command fails when the store doesn't already have a database
+expectStderr 1 nix-store --store local?read-only=true --add dummy | grepQuiet "unable to create database while in read-only mode"
+
+# Make sure the store actually has a current-database
+nix-store --add dummy
+
+# Try again and make sure we fail when adding a item not already in the store
+expectStderr 1 nix-store --store local?read-only=true --add eval.nix | grepQuiet "attempt to write a readonly database"
+
+# Make sure we can get an already-present store-path in the database
+nix-store --store local?read-only=true --add dummy
+
+## Ensure store is actually read-only
+chmod -R -w $TEST_ROOT/store
+chmod -R -w $TEST_ROOT/var
+
+# Make sure we fail on add operations on the read-only store
+# This is only for adding files that are not *already* in the store
+expectStderr 1 nix-store --add eval.nix | grepQuiet "error: opening lock file '$(readlink -e $TEST_ROOT)/var/nix/db/big-lock'"
+expectStderr 1 nix-store --store local?read-only=true --add eval.nix | grepQuiet "Permission denied"
+
+# Should succeed
+nix-store --store local?read-only=true --add dummy


### PR DESCRIPTION
Make sure we don't go down the path of making temproots when doing operations on a read-only store

# Motivation
<!-- Briefly explain what the change is about and why it is desirable. -->

# Context
<!-- Provide context. Reference open issues if available. -->

<!-- Non-trivial change: Briefly outline the implementation strategy. -->

<!-- Invasive change: Discuss alternative designs or approaches you considered. -->

<!-- Large change: Provide instructions to reviewers how to read the diff. -->

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] documentation in the internal API docs
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
