### PR TITLE
Implement deduplication and add more test cases

### DIFF
--- a/src/libstore/local-overlay-store.cc
+++ b/src/libstore/local-overlay-store.cc
@@ -188,6 +188,11 @@ void LocalOverlayStore::deleteGCPath(const Path & path, uint64_t & bytesFreed)
     }
 }
 
+void LocalOverlayStore::optimiseStore()
+{
+    warn("not implemented");
+}
+
 bool LocalOverlayStore::verifyStore(bool checkContents, RepairFlag repair)
 {
     if (repair)

--- a/src/libstore/local-overlay-store.cc
+++ b/src/libstore/local-overlay-store.cc
@@ -188,6 +188,13 @@ void LocalOverlayStore::deleteGCPath(const Path & path, uint64_t & bytesFreed)
     }
 }
 
+bool LocalOverlayStore::verifyStore(bool checkContents, RepairFlag repair)
+{
+    if (repair)
+        warn("local-overlay: store does not support --verify --repair");
+    return LocalStore::verifyStore(checkContents, NoRepair);
+}
+
 static RegisterStoreImplementation<LocalOverlayStore, LocalOverlayStoreConfig> regLocalOverlayStore;
 
 }

--- a/src/libstore/local-overlay-store.cc
+++ b/src/libstore/local-overlay-store.cc
@@ -190,7 +190,23 @@ void LocalOverlayStore::deleteGCPath(const Path & path, uint64_t & bytesFreed)
 
 void LocalOverlayStore::optimiseStore()
 {
-    warn("not implemented");
+    Activity act(*logger, actOptimiseStore);
+
+    // Note for LocalOverlayStore, queryAllValidPaths only returns paths in upper layer
+    auto paths = queryAllValidPaths();
+
+    act.progress(0, paths.size());
+
+    uint64_t done = 0;
+
+    for (auto & path : paths) {
+        if (lowerStore->isValidPath(path)) {
+            // Deduplicate store path
+            deletePath(toUpperPath(path));
+        }
+        done++;
+        act.progress(done, paths.size());
+    }
 }
 
 bool LocalOverlayStore::verifyStore(bool checkContents, RepairFlag repair)

--- a/src/libstore/local-overlay-store.hh
+++ b/src/libstore/local-overlay-store.hh
@@ -112,6 +112,8 @@ private:
         Callback<std::shared_ptr<const Realisation>> callback) noexcept override;
 
     void deleteGCPath(const Path & path, uint64_t & bytesFreed) override;
+
+    bool verifyStore(bool checkContents, RepairFlag repair) override;
 };
 
 }

--- a/src/libstore/local-overlay-store.hh
+++ b/src/libstore/local-overlay-store.hh
@@ -113,6 +113,8 @@ private:
 
     void deleteGCPath(const Path & path, uint64_t & bytesFreed) override;
 
+    void optimiseStore() override;
+
     bool verifyStore(bool checkContents, RepairFlag repair) override;
 };
 

--- a/tests/build-remote-trustless-should-fail-0.sh
+++ b/tests/build-remote-trustless-should-fail-0.sh
@@ -2,7 +2,6 @@ source common.sh
 
 enableFeatures "daemon-trust-override"
 
-requireSandboxSupport
 restartDaemon
 
 [[ $busybox =~ busybox ]] || skipTest "no busybox"

--- a/tests/common/vars-and-functions.sh.in
+++ b/tests/common/vars-and-functions.sh.in
@@ -141,7 +141,7 @@ restartDaemon() {
     startDaemon
 }
 
-if [[ -z "${_NIX_TEST_NO_SANDBOX:-}" ]] && [[ $(uname) == Linux ]] && [[ -L /proc/self/ns/user ]] && unshare --user true; then
+if [[ $(uname) == Linux ]] && [[ -L /proc/self/ns/user ]] && unshare --user true; then
     _canUseSandbox=1
 fi
 

--- a/tests/overlay-local-store/add-lower-inner.sh
+++ b/tests/overlay-local-store/add-lower-inner.sh
@@ -18,14 +18,14 @@ mountOverlayfs
 
 # Add something to the overlay store
 overlayPath=$(addTextToStore "$storeB" "overlay-file" "Add to overlay store")
-stat "$storeVolume/merged-store/$overlayPath"
+stat "$storeBRoot/$overlayPath"
 
 # Now add something to the lower store
 lowerPath=$(addTextToStore "$storeA" "lower-file" "Add to lower store")
 stat "$storeVolume/store-a/$lowerPath"
 
 # Remount overlayfs to ensure synchronization
-mount -o remount "$storeVolume/merged-store/nix/store"
+remountOverlayfs
 
 # Path should be accessible via overlay store
-stat "$storeVolume/merged-store/$lowerPath"
+stat "$storeBRoot/$lowerPath"

--- a/tests/overlay-local-store/add-lower-inner.sh
+++ b/tests/overlay-local-store/add-lower-inner.sh
@@ -18,14 +18,14 @@ mountOverlayfs
 
 # Add something to the overlay store
 overlayPath=$(addTextToStore "$storeB" "overlay-file" "Add to overlay store")
-stat "$TEST_ROOT/merged-store/$overlayPath"
+stat "$storeVolume/merged-store/$overlayPath"
 
 # Now add something to the lower store
 lowerPath=$(addTextToStore "$storeA" "lower-file" "Add to lower store")
-stat "$TEST_ROOT/store-a/$lowerPath"
+stat "$storeVolume/store-a/$lowerPath"
 
 # Remount overlayfs to ensure synchronization
-mount -o remount "$TEST_ROOT/merged-store/nix/store"
+mount -o remount "$storeVolume/merged-store/nix/store"
 
 # Path should be accessible via overlay store
-stat "$TEST_ROOT/merged-store/$lowerPath"
+stat "$storeVolume/merged-store/$lowerPath"

--- a/tests/overlay-local-store/add-lower-inner.sh
+++ b/tests/overlay-local-store/add-lower-inner.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+
+set -x
+
+source common.sh
+
+# Avoid store dir being inside sandbox build-dir
+unset NIX_STORE_DIR
+unset NIX_STATE_DIR
+
+storeDirs
+
+initLowerStore
+
+mountOverlayfs
+
+# Add something to the overlay store
+overlayPath=$(addTextToStore "$storeB" "overlay-file" "Add to overlay store")
+stat "$TEST_ROOT/merged-store/$overlayPath"
+
+# Now add something to the lower store
+lowerPath=$(addTextToStore "$storeA" "lower-file" "Add to lower store")
+stat "$TEST_ROOT/store-a/$lowerPath"
+
+# Remount overlayfs to ensure synchronization
+mount -o remount "$TEST_ROOT/merged-store/nix/store"
+
+# Path should be accessible via overlay store
+stat "$TEST_ROOT/merged-store/$lowerPath"

--- a/tests/overlay-local-store/add-lower.sh
+++ b/tests/overlay-local-store/add-lower.sh
@@ -1,0 +1,5 @@
+source common.sh
+
+requireEnvironment
+setupConfig
+execUnshare ./add-lower-inner.sh

--- a/tests/overlay-local-store/bad-uris.sh
+++ b/tests/overlay-local-store/bad-uris.sh
@@ -7,8 +7,8 @@ storeDirs
 mkdir -p $TEST_ROOT/bad_test
 badTestRoot=$TEST_ROOT/bad_test
 storeBadRoot="local-overlay?root=$badTestRoot&lower-store=$storeA&upper-layer=$storeBTop"
-storeBadLower="local-overlay?root=$storeVolume/merged-store&lower-store=$badTestRoot&upper-layer=$storeBTop"
-storeBadUpper="local-overlay?root=$storeVolume/merged-store&lower-store=$storeA&upper-layer=$badTestRoot"
+storeBadLower="local-overlay?root=$storeBRoot&lower-store=$badTestRoot&upper-layer=$storeBTop"
+storeBadUpper="local-overlay?root=$storeBRoot&lower-store=$storeA&upper-layer=$badTestRoot"
 
 declare -a storesBad=(
     "$storeBadRoot" "$storeBadLower" "$storeBadUpper"

--- a/tests/overlay-local-store/bad-uris.sh
+++ b/tests/overlay-local-store/bad-uris.sh
@@ -7,8 +7,8 @@ storeDirs
 mkdir -p $TEST_ROOT/bad_test
 badTestRoot=$TEST_ROOT/bad_test
 storeBadRoot="local-overlay?root=$badTestRoot&lower-store=$storeA&upper-layer=$storeBTop"
-storeBadLower="local-overlay?root=$TEST_ROOT/merged-store&lower-store=$badTestRoot&upper-layer=$storeBTop"
-storeBadUpper="local-overlay?root=$TEST_ROOT/merged-store&lower-store=$storeA&upper-layer=$badTestRoot"
+storeBadLower="local-overlay?root=$storeVolume/merged-store&lower-store=$badTestRoot&upper-layer=$storeBTop"
+storeBadUpper="local-overlay?root=$storeVolume/merged-store&lower-store=$storeA&upper-layer=$badTestRoot"
 
 declare -a storesBad=(
     "$storeBadRoot" "$storeBadLower" "$storeBadUpper"

--- a/tests/overlay-local-store/check-post-init-inner.sh
+++ b/tests/overlay-local-store/check-post-init-inner.sh
@@ -25,7 +25,7 @@ stat $(toRealPath "$storeA/nix/store" "$path")
 expect 1 stat $(toRealPath "$storeBTop" "$path")
 
 # Checking for path in overlay store matching lower layer
-diff $(toRealPath "$storeA/nix/store" "$path") $(toRealPath "$TEST_ROOT/merged-store/nix/store" "$path")
+diff $(toRealPath "$storeA/nix/store" "$path") $(toRealPath "$storeVolume/merged-store/nix/store" "$path")
 
 # Checking requisites query agreement
 [[ \

--- a/tests/overlay-local-store/check-post-init-inner.sh
+++ b/tests/overlay-local-store/check-post-init-inner.sh
@@ -25,7 +25,7 @@ stat $(toRealPath "$storeA/nix/store" "$path")
 expect 1 stat $(toRealPath "$storeBTop" "$path")
 
 # Checking for path in overlay store matching lower layer
-diff $(toRealPath "$storeA/nix/store" "$path") $(toRealPath "$storeVolume/merged-store/nix/store" "$path")
+diff $(toRealPath "$storeA/nix/store" "$path") $(toRealPath "$storeBRoot/nix/store" "$path")
 
 # Checking requisites query agreement
 [[ \

--- a/tests/overlay-local-store/check-post-init-inner.sh
+++ b/tests/overlay-local-store/check-post-init-inner.sh
@@ -62,7 +62,7 @@ nix-store --verify-path --store "$storeA" "$path"
 # Verifying path in merged-store
 nix-store --verify-path --store "$storeB" "$path"
 
-hashPart=$(echo $path | sed "s^$NIX_STORE_DIR/^^" | sed 's/-.*//')
+hashPart=$(echo $path | sed "s^${NIX_STORE_DIR:-/nix/store}/^^" | sed 's/-.*//')
 
 # Lower store can find from hash part
 [[ $(nix store --store $storeA path-from-hash-part $hashPart) == $path ]]

--- a/tests/overlay-local-store/common.sh
+++ b/tests/overlay-local-store/common.sh
@@ -8,7 +8,7 @@ requireEnvironment () {
 }
 
 setupConfig () {
-  echo "drop-supplementary-groups = false" >> "$NIX_CONF_DIR"/nix.conf
+  echo "require-drop-supplementary-groups = false" >> "$NIX_CONF_DIR"/nix.conf
   echo "build-users-group = " >> "$NIX_CONF_DIR"/nix.conf
 }
 
@@ -53,4 +53,13 @@ initLowerStore () {
 
 execUnshare () {
   exec unshare --mount --map-root-user "$@"
+}
+
+addTextToStore() {
+  storeDir=$1; shift
+  filename=$1; shift
+  content=$1; shift
+  filePath="$TEST_HOME/$filename"
+  echo "$content" > "$filePath"
+  nix-store --store "$storeDir" --add "$filePath"
 }

--- a/tests/overlay-local-store/common.sh
+++ b/tests/overlay-local-store/common.sh
@@ -13,26 +13,29 @@ setupConfig () {
 }
 
 storeDirs () {
-  storeA="$TEST_ROOT/store-a"
-  storeBTop="$TEST_ROOT/store-b"
-  storeB="local-overlay?root=$TEST_ROOT/merged-store&lower-store=$storeA&upper-layer=$storeBTop"
+  storesRoot="$TEST_ROOT/stores"
+  mkdir -p "$storesRoot"
+  mount -t tmpfs tmpfs "$storesRoot"
+  storeA="$storesRoot/store-a"
+  storeBTop="$storesRoot/store-b"
+  storeB="local-overlay?root=$storesRoot/merged-store&lower-store=$storeA&upper-layer=$storeBTop"
   # Creating testing directories
-  mkdir -p "$TEST_ROOT"/{store-a/nix/store,store-b,merged-store/nix/store,workdir}
+  mkdir -p "$storesRoot"/{store-a/nix/store,store-b,merged-store/nix/store,workdir}
 }
 
 # Mounting Overlay Store
 mountOverlayfs () {
-  mergedStorePath="$TEST_ROOT/merged-store/nix/store"
+  mergedStorePath="$storesRoot/merged-store/nix/store"
   mount -t overlay overlay \
     -o lowerdir="$storeA/nix/store" \
     -o upperdir="$storeBTop" \
-    -o workdir="$TEST_ROOT/workdir" \
+    -o workdir="$storesRoot/workdir" \
     "$mergedStorePath" \
     || skipTest "overlayfs is not supported"
 
   cleanupOverlay () {
-    umount "$TEST_ROOT/merged-store/nix/store"
-    rm -r $TEST_ROOT/workdir
+    umount "$storesRoot/merged-store/nix/store"
+    rm -r $storesRoot/workdir
   }
   trap cleanupOverlay EXIT
 }

--- a/tests/overlay-local-store/common.sh
+++ b/tests/overlay-local-store/common.sh
@@ -53,7 +53,7 @@ remountOverlayfs () {
 toRealPath () {
   storeDir=$1; shift
   storePath=$1; shift
-  echo $storeDir$(echo $storePath | sed "s^$NIX_STORE_DIR^^")
+  echo $storeDir$(echo $storePath | sed "s^${NIX_STORE_DIR:-/nix/store}^^")
 }
 
 initLowerStore () {

--- a/tests/overlay-local-store/common.sh
+++ b/tests/overlay-local-store/common.sh
@@ -22,11 +22,12 @@ storeDirs () {
 
 # Mounting Overlay Store
 mountOverlayfs () {
+  mergedStorePath="$TEST_ROOT/merged-store/nix/store"
   mount -t overlay overlay \
     -o lowerdir="$storeA/nix/store" \
     -o upperdir="$storeBTop" \
     -o workdir="$TEST_ROOT/workdir" \
-    "$TEST_ROOT/merged-store/nix/store" \
+    "$mergedStorePath" \
     || skipTest "overlayfs is not supported"
 
   cleanupOverlay () {
@@ -34,6 +35,10 @@ mountOverlayfs () {
     rm -r $TEST_ROOT/workdir
   }
   trap cleanupOverlay EXIT
+}
+
+remountOverlayfs () {
+  mount -o remount "$mergedStorePath"
 }
 
 toRealPath () {
@@ -53,13 +58,4 @@ initLowerStore () {
 
 execUnshare () {
   exec unshare --mount --map-root-user "$@"
-}
-
-addTextToStore() {
-  storeDir=$1; shift
-  filename=$1; shift
-  content=$1; shift
-  filePath="$TEST_HOME/$filename"
-  echo "$content" > "$filePath"
-  nix-store --store "$storeDir" --add "$filePath"
 }

--- a/tests/overlay-local-store/common.sh
+++ b/tests/overlay-local-store/common.sh
@@ -12,30 +12,36 @@ setupConfig () {
   echo "build-users-group = " >> "$NIX_CONF_DIR"/nix.conf
 }
 
+
+
 storeDirs () {
-  storesRoot="$TEST_ROOT/stores"
-  mkdir -p "$storesRoot"
-  mount -t tmpfs tmpfs "$storesRoot"
-  storeA="$storesRoot/store-a"
-  storeBTop="$storesRoot/store-b"
-  storeB="local-overlay?root=$storesRoot/merged-store&lower-store=$storeA&upper-layer=$storeBTop"
+  # Attempt to create store dirs on tmpfs volume.
+  # This ensures lowerdir, upperdir and workdir will be on
+  # a consistent filesystem that fully supports OverlayFS.
+  storeVolume="$TEST_ROOT/stores"
+  mkdir -p "$storeVolume"
+  mount -t tmpfs tmpfs "$storeVolume" || true  # But continue anyway if that fails.
+
+  storeA="$storeVolume/store-a"
+  storeBTop="$storeVolume/store-b"
+  storeB="local-overlay?root=$storeVolume/merged-store&lower-store=$storeA&upper-layer=$storeBTop"
   # Creating testing directories
-  mkdir -p "$storesRoot"/{store-a/nix/store,store-b,merged-store/nix/store,workdir}
+  mkdir -p "$storeVolume"/{store-a/nix/store,store-b,merged-store/nix/store,workdir}
 }
 
 # Mounting Overlay Store
 mountOverlayfs () {
-  mergedStorePath="$storesRoot/merged-store/nix/store"
+  mergedStorePath="$storeVolume/merged-store/nix/store"
   mount -t overlay overlay \
     -o lowerdir="$storeA/nix/store" \
     -o upperdir="$storeBTop" \
-    -o workdir="$storesRoot/workdir" \
+    -o workdir="$storeVolume/workdir" \
     "$mergedStorePath" \
     || skipTest "overlayfs is not supported"
 
   cleanupOverlay () {
-    umount "$storesRoot/merged-store/nix/store"
-    rm -r $storesRoot/workdir
+    umount "$storeVolume/merged-store/nix/store"
+    rm -r $storeVolume/workdir
   }
   trap cleanupOverlay EXIT
 }

--- a/tests/overlay-local-store/common.sh
+++ b/tests/overlay-local-store/common.sh
@@ -24,30 +24,30 @@ storeDirs () {
 
   storeA="$storeVolume/store-a"
   storeBTop="$storeVolume/store-b"
-  storeB="local-overlay?root=$storeVolume/merged-store&lower-store=$storeA&upper-layer=$storeBTop"
+  storeBRoot="$storeVolume/merged-store"
+  storeB="local-overlay?root=$storeBRoot&lower-store=$storeA&upper-layer=$storeBTop"
   # Creating testing directories
   mkdir -p "$storeVolume"/{store-a/nix/store,store-b,merged-store/nix/store,workdir}
 }
 
 # Mounting Overlay Store
 mountOverlayfs () {
-  mergedStorePath="$storeVolume/merged-store/nix/store"
   mount -t overlay overlay \
     -o lowerdir="$storeA/nix/store" \
     -o upperdir="$storeBTop" \
     -o workdir="$storeVolume/workdir" \
-    "$mergedStorePath" \
+    "$storeBRoot/nix/store" \
     || skipTest "overlayfs is not supported"
 
   cleanupOverlay () {
-    umount "$storeVolume/merged-store/nix/store"
+    umount "$storeBRoot/nix/store"
     rm -r $storeVolume/workdir
   }
   trap cleanupOverlay EXIT
 }
 
 remountOverlayfs () {
-  mount -o remount "$mergedStorePath"
+  mount -o remount "$storeBRoot/nix/store"
 }
 
 toRealPath () {

--- a/tests/overlay-local-store/common.sh
+++ b/tests/overlay-local-store/common.sh
@@ -57,5 +57,5 @@ initLowerStore () {
 }
 
 execUnshare () {
-  exec unshare --mount --map-root-user "$@"
+  exec unshare --mount --map-root-user "$SHELL" "$@"
 }

--- a/tests/overlay-local-store/common.sh
+++ b/tests/overlay-local-store/common.sh
@@ -59,3 +59,12 @@ initLowerStore () {
 execUnshare () {
   exec unshare --mount --map-root-user "$SHELL" "$@"
 }
+
+addTextToStore() {
+  storeDir=$1; shift
+  filename=$1; shift
+  content=$1; shift
+  filePath="$TEST_HOME/$filename"
+  echo "$content" > "$filePath"
+  nix-store --store "$storeDir" --add "$filePath"
+}

--- a/tests/overlay-local-store/local.mk
+++ b/tests/overlay-local-store/local.mk
@@ -3,6 +3,7 @@ overlay-local-store-tests := \
   $(d)/redundant-add.sh \
   $(d)/build.sh \
   $(d)/bad-uris.sh \
-  $(d)/add-lower.sh
+  $(d)/add-lower.sh \
+  $(d)/verify.sh
 
 install-tests-groups += overlay-local-store

--- a/tests/overlay-local-store/local.mk
+++ b/tests/overlay-local-store/local.mk
@@ -2,6 +2,7 @@ overlay-local-store-tests := \
   $(d)/check-post-init.sh \
   $(d)/redundant-add.sh \
   $(d)/build.sh \
-  $(d)/bad-uris.sh
+  $(d)/bad-uris.sh \
+  $(d)/add-lower.sh
 
 install-tests-groups += overlay-local-store

--- a/tests/overlay-local-store/local.mk
+++ b/tests/overlay-local-store/local.mk
@@ -4,6 +4,7 @@ overlay-local-store-tests := \
   $(d)/build.sh \
   $(d)/bad-uris.sh \
   $(d)/add-lower.sh \
-  $(d)/verify.sh
+  $(d)/verify.sh \
+  $(d)/optimise.sh
 
 install-tests-groups += overlay-local-store

--- a/tests/overlay-local-store/optimise-inner.sh
+++ b/tests/overlay-local-store/optimise-inner.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+
+set -x
+
+source common.sh
+
+# Avoid store dir being inside sandbox build-dir
+unset NIX_STORE_DIR
+unset NIX_STATE_DIR
+
+storeDirs
+
+initLowerStore
+
+mountOverlayfs
+
+nix-store --store "$storeB" --optimise

--- a/tests/overlay-local-store/optimise-inner.sh
+++ b/tests/overlay-local-store/optimise-inner.sh
@@ -16,4 +16,37 @@ initLowerStore
 
 mountOverlayfs
 
+# Create a file to add to store
+dupFilePath="$TEST_ROOT/dup-file"
+echo Duplicate > "$dupFilePath"
+
+# Add it to the overlay store (it will be written to the upper layer)
+dupFileStorePath=$(nix-store --store "$storeB" --add "$dupFilePath")
+
+# Now add it to the lower store so the store path is duplicated
+nix-store --store "$storeA" --add "$dupFilePath"
+
+# Ensure overlayfs and layers and synchronised
+remountOverlayfs
+
+dupFilename="${dupFileStorePath#/nix/store}"
+lowerPath="$storeA/$dupFileStorePath"
+upperPath="$storeBTop/$dupFilename"
+overlayPath="$mergedStorePath/$dupFilename"
+
+# Check store path exists in both layers and overlay
+lowerInode=$(stat -c %i "$lowerPath")
+upperInode=$(stat -c %i "$upperPath")
+overlayInode=$(stat -c %i "$overlayPath")
+[[ $upperInode == $overlayInode ]]
+[[ $upperInode != $lowerInode ]]
+
+# Run optimise to deduplicate store paths
 nix-store --store "$storeB" --optimise
+remountOverlayfs
+
+stat "$lowerPath"
+stat "$overlayPath"
+expect 1 stat "$upperPath"
+
+#expect 1 stat $(toRealPath "$storeA/nix/store" "$path")

--- a/tests/overlay-local-store/optimise-inner.sh
+++ b/tests/overlay-local-store/optimise-inner.sh
@@ -32,7 +32,7 @@ remountOverlayfs
 dupFilename="${dupFileStorePath#/nix/store}"
 lowerPath="$storeA/$dupFileStorePath"
 upperPath="$storeBTop/$dupFilename"
-overlayPath="$mergedStorePath/$dupFilename"
+overlayPath="$storeBRoot/nix/store/$dupFilename"
 
 # Check store path exists in both layers and overlay
 lowerInode=$(stat -c %i "$lowerPath")

--- a/tests/overlay-local-store/optimise-inner.sh
+++ b/tests/overlay-local-store/optimise-inner.sh
@@ -45,8 +45,7 @@ overlayInode=$(stat -c %i "$overlayPath")
 nix-store --store "$storeB" --optimise
 remountOverlayfs
 
+# Check path only exists in lower store
 stat "$lowerPath"
 stat "$overlayPath"
 expect 1 stat "$upperPath"
-
-#expect 1 stat $(toRealPath "$storeA/nix/store" "$path")

--- a/tests/overlay-local-store/optimise-inner.sh
+++ b/tests/overlay-local-store/optimise-inner.sh
@@ -17,7 +17,7 @@ initLowerStore
 mountOverlayfs
 
 # Create a file to add to store
-dupFilePath="$storesRoot/dup-file"
+dupFilePath="$TEST_ROOT/dup-file"
 echo Duplicate > "$dupFilePath"
 
 # Add it to the overlay store (it will be written to the upper layer)

--- a/tests/overlay-local-store/optimise-inner.sh
+++ b/tests/overlay-local-store/optimise-inner.sh
@@ -17,7 +17,7 @@ initLowerStore
 mountOverlayfs
 
 # Create a file to add to store
-dupFilePath="$TEST_ROOT/dup-file"
+dupFilePath="$storesRoot/dup-file"
 echo Duplicate > "$dupFilePath"
 
 # Add it to the overlay store (it will be written to the upper layer)

--- a/tests/overlay-local-store/optimise.sh
+++ b/tests/overlay-local-store/optimise.sh
@@ -1,0 +1,5 @@
+source common.sh
+
+requireEnvironment
+setupConfig
+execUnshare ./optimise-inner.sh

--- a/tests/overlay-local-store/redundant-add-inner.sh
+++ b/tests/overlay-local-store/redundant-add-inner.sh
@@ -7,7 +7,7 @@ set -x
 source common.sh
 
 # Avoid store dir being inside sandbox build-dir
-unset NIX_STORE_DIR
+unset NIX_STORE_DIR  # TODO: This causes toRealPath to fail (it expects this var to be set)
 unset NIX_STATE_DIR
 
 storeDirs
@@ -27,4 +27,5 @@ path=$(nix-store --store "$storeB" --add ../dummy)
 stat $(toRealPath "$storeA/nix/store" "$path")
 
 # upper layer should still not have it (no redundant copy)
-expect 1 stat $(toRealPath "$storeB/nix/store" "$path")
+expect 1 stat $(toRealPath "$storeB/nix/store" "$path")  # TODO: Check this is failing for the right reason.
+                                                         # $storeB is a store URI not a directory path

--- a/tests/overlay-local-store/redundant-add-inner.sh
+++ b/tests/overlay-local-store/redundant-add-inner.sh
@@ -7,7 +7,7 @@ set -x
 source common.sh
 
 # Avoid store dir being inside sandbox build-dir
-unset NIX_STORE_DIR  # TODO: This causes toRealPath to fail (it expects this var to be set)
+unset NIX_STORE_DIR
 unset NIX_STATE_DIR
 
 storeDirs
@@ -27,5 +27,4 @@ path=$(nix-store --store "$storeB" --add ../dummy)
 stat $(toRealPath "$storeA/nix/store" "$path")
 
 # upper layer should still not have it (no redundant copy)
-expect 1 stat $(toRealPath "$storeB/nix/store" "$path")  # TODO: Check this is failing for the right reason.
-                                                         # $storeB is a store URI not a directory path
+expect 1 stat $(toRealPath "$storeBTop" "$path")

--- a/tests/overlay-local-store/verify-inner.sh
+++ b/tests/overlay-local-store/verify-inner.sh
@@ -34,6 +34,7 @@ rm -v "$inputDrvFullPath"
 find "$storeA" -name "*-dummy" -exec truncate -s 0 {} \;
 
 # Verify should fail with the messages about missing input and modified dummy file
-verifyOutput=$(expectStderr 1 nix-store --store "$storeB" --verify --check-contents)
+verifyOutput=$(expectStderr 1 nix-store --store "$storeB" --verify --check-contents --repair)
 <<<"$verifyOutput" grepQuiet "path '$inputDrvPath' disappeared, but it still has valid referrers!"
 <<<"$verifyOutput" grepQuiet "path '$dummyPath' was modified! expected hash"
+<<<"$verifyOutput" grepQuiet "store does not support --verify --repair"

--- a/tests/overlay-local-store/verify-inner.sh
+++ b/tests/overlay-local-store/verify-inner.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+
+set -x
+
+source common.sh
+
+# Avoid store dir being inside sandbox build-dir
+unset NIX_STORE_DIR
+unset NIX_STATE_DIR
+
+storeDirs
+
+initLowerStore
+
+mountOverlayfs
+
+#path=$(nix-store --store "$storeB" --add ../dummy)
+
+path=$(nix-build --store $storeB ../hermetic.nix --arg busybox "$busybox" --arg seed 1)
+
+inputDrvPath=$(find "$storeA" -name "*-hermetic-input-1.drv")
+rm -v "$inputDrvPath"
+
+#tree "$TEST_ROOT"
+
+#rm -v "$TEST_ROOT/store-a/$path"
+
+nix-store --store "$storeB" --verify
+
+echo "SUCCESS"

--- a/tests/overlay-local-store/verify.sh
+++ b/tests/overlay-local-store/verify.sh
@@ -1,0 +1,5 @@
+source common.sh
+
+requireEnvironment
+setupConfig
+execUnshare ./verify-inner.sh


### PR DESCRIPTION
- Test that a path subsequently added to lower store is accessible via overlay store
- Add test for `nix-store --verify` and implement it (mostly just delegate to existing behaviour, but disallow `--repair`)
- Add test for `nix-store --optimise` and implement deduplication / optimisation for overlay store
- Fix various issues with other overlay store tests