### PR TITLE
Add a GC test, fix hardlinking issue

### DIFF
--- a/src/libstore/local-fs-store.hh
+++ b/src/libstore/local-fs-store.hh
@@ -73,6 +73,16 @@ public:
         return getRealStoreDir() + "/" + std::string(storePath, storeDir.size() + 1);
     }
 
+    /**
+     * If the real path is hardlinked with something else, we might
+     * prefer to refer to the other path instead. This is the case with
+     * overlayfs, for example.
+     */
+    virtual Path toRealPathForHardLink(const StorePath & storePath)
+    {
+        return Store::toRealPath(storePath);
+    }
+
     std::optional<std::string> getBuildLogExact(const StorePath & path) override;
 
 };

--- a/src/libstore/local-overlay-store.cc
+++ b/src/libstore/local-overlay-store.cc
@@ -209,6 +209,13 @@ void LocalOverlayStore::optimiseStore()
     }
 }
 
+Path LocalOverlayStore::toRealPathForHardLink(const StorePath & path)
+{
+    return lowerStore->isValidPath(path)
+        ? lowerStore->Store::toRealPath(path)
+        : Store::toRealPath(path);
+}
+
 static RegisterStoreImplementation<LocalOverlayStore, LocalOverlayStoreConfig> regLocalOverlayStore;
 
 }

--- a/src/libstore/local-overlay-store.hh
+++ b/src/libstore/local-overlay-store.hh
@@ -114,6 +114,8 @@ private:
     void deleteGCPath(const Path & path, uint64_t & bytesFreed) override;
 
     void optimiseStore() override;
+
+    Path toRealPathForHardLink(const StorePath & storePath) override;
 };
 
 }

--- a/tests/overlay-local-store/gc-inner.sh
+++ b/tests/overlay-local-store/gc-inner.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+
+source common.sh
+
+# Avoid store dir being inside sandbox build-dir
+unset NIX_STORE_DIR
+unset NIX_STATE_DIR
+
+storeDirs
+
+initLowerStore
+
+mountOverlayfs
+
+export NIX_REMOTE="$storeB"
+stateB="$storeBRoot/nix/var/nix"
+outPath=$(nix-build ../hermetic.nix --no-out-link --arg busybox "$busybox" --arg seed 2)
+
+# Set a GC root.
+mkdir -p "$stateB"
+rm -f "$stateB"/gcroots/foo
+ln -sf $outPath "$stateB"/gcroots/foo
+
+[ "$(nix-store -q --roots $outPath)" = "$stateB/gcroots/foo -> $outPath" ]
+
+nix-store --gc --print-roots | grep $outPath
+nix-store --gc --print-live | grep $outPath
+if nix-store --gc --print-dead | grep -E $outPath$; then false; fi
+
+nix-store --gc --print-dead
+
+expect 1 nix-store --delete $outPath
+test -e "$storeBRoot/$outPath"
+
+shopt -s nullglob
+for i in $storeBRoot/*; do
+    if [[ $i =~ /trash ]]; then continue; fi # compat with old daemon
+    touch $i.lock
+    touch $i.chroot
+done
+
+nix-collect-garbage
+
+# Check that the root and its dependencies haven't been deleted.
+cat "$storeBRoot/$outPath"
+
+rm "$stateB"/gcroots/foo
+
+nix-collect-garbage
+
+# Check that the output has been GC'd.
+test ! -e $outPath
+
+# Check that the store is empty.
+[ "$(ls -1 "$storeBTop" | wc -l)" = "0" ]

--- a/tests/overlay-local-store/gc.sh
+++ b/tests/overlay-local-store/gc.sh
@@ -1,0 +1,5 @@
+source common.sh
+
+requireEnvironment
+setupConfig
+execUnshare ./gc-inner.sh

--- a/tests/overlay-local-store/local.mk
+++ b/tests/overlay-local-store/local.mk
@@ -4,6 +4,7 @@ overlay-local-store-tests := \
   $(d)/build.sh \
   $(d)/bad-uris.sh \
   $(d)/add-lower.sh \
+  $(d)/gc.sh \
   $(d)/verify.sh \
   $(d)/optimise.sh
 


### PR DESCRIPTION
# Motivation

This identifies and then fixes and issue with hard linking during a build (when preparing the chroot dir) causing items to be copied up. The solution is just to hard link with the lower layer for lower-layer items.

There is already fallback logic so if the hard-link fails, copping will be done instead.

# Context

This wasn't the GC issues I intended to fix. So there will be another PR afterwords.

# Checklist for maintainers

<!-- Contributors: please leave this as is -->

Maintainers: tick if completed or explain if not relevant

 - [ ] agreed on idea
 - [ ] agreed on implementation strategy
 - [ ] tests, as appropriate
   - functional tests - `tests/**.sh`
   - unit tests - `src/*/tests`
   - integration tests - `tests/nixos/*`
 - [ ] documentation in the manual
 - [ ] documentation in the internal API docs
 - [ ] code and comments are self-explanatory
 - [ ] commit message explains why the change was made
 - [ ] new feature or incompatible change: updated release notes

# Priorities

Add :+1: to [pull requests you find important](https://github.com/NixOS/nix/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc).
