### PR TITLE
Avoid enumerating entire overlay store dir upfront

### DIFF
--- a/src/libstore/local-overlay-store.cc
+++ b/src/libstore/local-overlay-store.cc
@@ -243,6 +243,22 @@ void LocalOverlayStore::optimiseStore()
 }
 
 
+bool LocalOverlayStore::verifyAllValidPaths(RepairFlag repair, StorePathSet & validPaths)
+{
+    StorePathSet done;
+    bool errors = false;
+
+    auto existsInStoreDir = [&](const StorePath & storePath) {
+        return pathExists(realStoreDir.get() + "/" + storePath.to_string());
+    };
+
+    for (auto & i : queryAllValidPaths())
+        verifyPath(i, existsInStoreDir, done, validPaths, repair, errors);
+
+    return errors;
+}
+
+
 Path LocalOverlayStore::toRealPathForHardLink(const StorePath & path)
 {
     return lowerStore->isValidPath(path)

--- a/src/libstore/local-overlay-store.hh
+++ b/src/libstore/local-overlay-store.hh
@@ -124,6 +124,8 @@ private:
 
     void optimiseStore() override;
 
+    bool verifyAllValidPaths(RepairFlag repair, StorePathSet & validPaths) override;
+
     /**
      * For lower-store paths, we used the lower store location. This avoids the
      * wasteful "copying up" that would otherwise happen.

--- a/src/libstore/local-overlay-store.hh
+++ b/src/libstore/local-overlay-store.hh
@@ -43,9 +43,15 @@ struct LocalOverlayStoreConfig : virtual LocalStoreConfig
 
     const PathSetting remountHook{(StoreConfig*) this, "", "remount-hook",
         R"(
-          Script or program to run when overlay filesystem needs remounting.
+          Script or other executable to run when overlay filesystem needs remounting.
 
-          TODO: Document this in more detail.
+          This is occasionally necessary when deleting a store path that exists in both upper and lower layers.
+          In such a situation, bypassing OverlayFS and deleting the path in the upper layer directly
+          is the only way to perform the deletion without creating a "whiteout".
+          However this causes the OverlayFS kernel data structures to get out-of-sync,
+          and can lead to 'stale file handle' errors; remounting solves the problem.
+
+          The store directory is passed as an argument to the invoked executable.
         )"};
 
     const std::string name() override { return "Experimental Local Overlay Store"; }

--- a/src/libstore/local-overlay-store.hh
+++ b/src/libstore/local-overlay-store.hh
@@ -127,9 +127,11 @@ private:
     /**
      * Check all paths registered in the upper DB.
      *
-     * Note that this includes store objects that reside in either overlayfs layer; just enumerating the contents of the upper layer would skip them.
+     * Note that this includes store objects that reside in either overlayfs layer;
+     * just enumerating the contents of the upper layer would skip them.
      * 
-     * We don't verify the contents of both layers on the assumption that the lower layer is far bigger, and also the observation that anything not in the upper db the overlayfs doesn't yet care about.  
+     * We don't verify the contents of both layers on the assumption that the lower layer is far bigger,
+     * and also the observation that anything not in the upper db the overlayfs doesn't yet care about.
      */
     bool verifyAllValidPaths(RepairFlag repair, StorePathSet & validPaths) override;
 

--- a/src/libstore/local-overlay-store.hh
+++ b/src/libstore/local-overlay-store.hh
@@ -124,6 +124,13 @@ private:
 
     void optimiseStore() override;
 
+    /**
+     * Check all paths registered in the upper DB.
+     *
+     * Note that this includes store objects that reside in either overlayfs layer; just enumerating the contents of the upper layer would skip them.
+     * 
+     * We don't verify the contents of both layers on the assumption that the lower layer is far bigger, and also the observation that anything not in the upper db the overlayfs doesn't yet care about.  
+     */
     bool verifyAllValidPaths(RepairFlag repair, StorePathSet & validPaths) override;
 
     /**

--- a/src/libstore/local-store.hh
+++ b/src/libstore/local-store.hh
@@ -265,6 +265,8 @@ public:
 
     bool verifyStore(bool checkContents, RepairFlag repair) override;
 
+    virtual bool verifyAllValidPaths(RepairFlag repair, StorePathSet & validPaths);
+
     /**
      * Register the validity of a path, i.e., that `path` exists, that
      * the paths referenced by it exists, and in the case of an output
@@ -333,8 +335,8 @@ private:
      */
     void invalidatePathChecked(const StorePath & path);
 
-    void verifyPath(const Path & path, const StringSet & store,
-        PathSet & done, StorePathSet & validPaths, RepairFlag repair, bool & errors);
+    void verifyPath(const StorePath & path, std::function<bool(const StorePath &)> existsInStoreDir,
+        StorePathSet & done, StorePathSet & validPaths, RepairFlag repair, bool & errors);
 
     std::shared_ptr<const ValidPathInfo> queryPathInfoInternal(State & state, const StorePath & path);
 

--- a/src/libstore/local-store.hh
+++ b/src/libstore/local-store.hh
@@ -312,6 +312,11 @@ public:
 
     std::optional<std::string> getVersion() override;
 
+protected:
+
+    void verifyPath(const StorePath & path, std::function<bool(const StorePath &)> existsInStoreDir,
+        StorePathSet & done, StorePathSet & validPaths, RepairFlag repair, bool & errors);
+
 private:
 
     /**
@@ -334,9 +339,6 @@ private:
      * Delete a path from the Nix store.
      */
     void invalidatePathChecked(const StorePath & path);
-
-    void verifyPath(const StorePath & path, std::function<bool(const StorePath &)> existsInStoreDir,
-        StorePathSet & done, StorePathSet & validPaths, RepairFlag repair, bool & errors);
 
     std::shared_ptr<const ValidPathInfo> queryPathInfoInternal(State & state, const StorePath & path);
 

--- a/tests/overlay-local-store/verify-inner.sh
+++ b/tests/overlay-local-store/verify-inner.sh
@@ -50,6 +50,9 @@ find "$storeA" -name "*-dummy" -exec truncate -s 0 {} \;
 # Also truncate the file that only exists in lower store
 truncate -s 0 "$storeA/$lowerOnlyPath"
 
+# Ensure overlayfs is synchronised
+remountOverlayfs
+
 
 ## Now test that verify and repair work as expected
 


### PR DESCRIPTION
As an optimisation for `LocalStore`, we read all the store directory entries into a set. Checking for membership of this set is much faster than a `stat` syscall.  However for `LocalOverlayStore`, the lower store directory is expected to contain a vast number of entries and reading them all can take a very long time.

So instead of enumerating them all upfront, we call `pathExists` as needed. This means making `stat` syscalls for each store path, but the upper layer is expected to be relatively small compared to the lower store so that should be okay.